### PR TITLE
Add FlexibleBottomSheet and compose-stable-marker

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -881,6 +881,10 @@ your Compose apps.
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.team-preat/peekaboo-image-picker)](https://search.maven.org/search?q=g:io.github.team-preat)
 > Kotlin Multiplatform library for Compose Multiplatform, designed for seamless integration of an image picker feature in iOS and Android applications.
 
+[FlexibleBottomSheet](https://github.com/skydoves/FlexibleBottomSheet) - Flexible BottomSheet library Compose Multiplatform [![GitHub Repo stars](https://img.shields.io/github/stars/skydoves/FlexibleBottomSheet)](https://img.shields.io/github/stars/skydoves/FlexibleBottomSheet)
+[![Maven Central](https://img.shields.io/maven-central/v/com.github.skydoves/flexible-core.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.github.skydoves%22%20AND%20a:%flexible-core%22)
+> Advanced Compose Multiplatform bottom sheet for segmented sizing and non-modal type, similar to Google Maps.
+
 ### 🎨 Graphics
 [MOKO Graphics](https://github.com/icerockdev/moko-graphics) - Graphics primitives
 [![GitHub Repo stars](https://img.shields.io/github/stars/icerockdev/moko-graphics)](https://github.com/icerockdev/moko-graphics)


### PR DESCRIPTION
Add FlexibleBottomSheet.

[FlexibleBottomSheet](https://github.com/skydoves/FlexibleBottomSheet) is an advanced Jetpack Compose Multiplatform bottom sheet that allows you to implement segmented sizing and non-modal type, similar to Google Maps. It also offers additional conveniences, including specifying sheet sizes, monitoring sheet states, and more customization.