### PR TITLE
Add Compose Action Menu

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -916,6 +916,10 @@ your Compose apps.
 [![Maven Central](https://img.shields.io/maven-central/v/moe.tlaster/precompose)](https://central.sonatype.com/artifact/moe.tlaster/precompose)
 > Compose Multiplatform Navigation && ViewModel library, inspired by Jetpack Navigation, ViewModel and Lifecycle.
 
+[Compose Action Menu](https://github.com/jacobras/ComposeActionMenu) An easy-to-use action/overflow menu for Compose UI.
+[![GitHub Repo stars](https://img.shields.io/github/stars/jacobras/composeactionmenu?style=flat)](https://github.com/jacobras/ComposeActionMenu/stargazers)
+[![Maven Central](https://img.shields.io/maven-central/v/nl.jacobras/compose-action-menu)](https://central.sonatype.com/artifact/nl.jacobras/compose-action-menu)
+
 ### 🎨 Graphics
 [MOKO Graphics](https://github.com/icerockdev/moko-graphics) - Graphics primitives
 [![GitHub Repo stars](https://img.shields.io/github/stars/icerockdev/moko-graphics?style=flat)](https://github.com/icerockdev/moko-graphics)


### PR DESCRIPTION
[Compose Action Menu](https://github.com/jacobras/ComposeActionMenu) provides an easy-to-use menu like Android's options menu (with selectable items, submenus and automatic overflow) and is now (since v2.0.0) built with Compose Multiplatform.